### PR TITLE
Close toast on button click

### DIFF
--- a/toast-er.html
+++ b/toast-er.html
@@ -291,7 +291,9 @@ Property     | Value           | Description
       },
 
       _buttonTap: function(event) {
-        this.fire("toaster-" + event.target.buttonEvent);
+        this.fire('toaster-' + event.target.buttonEvent);
+        this.$.toast.close();
+        this._emptyTheToaster();
       },
 
       /**


### PR DESCRIPTION
With this commit, the toasts who have a button are closed when the
button is clicked. Before the user was waiting the end of the duration,
which is at least 10 sec when the toast has a button.

Closes #27
