### PR TITLE
chore(build): pin Firefox version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ node_js: stable
 sudo: required
 dist: trusty
 addons:
-  firefox: latest
+  firefox: '66.0'
   sauce_connect: true
   apt:
     sources:


### PR DESCRIPTION
Pin Firefox version to v66.0 because from v67.0 and higher
Geckodriver v.0.24.0 is required and Polymer CLI does not
use it yet.